### PR TITLE
Updated "shell prompt" (to give a Debian feel)

### DIFF
--- a/kippo/core/honeypot.py
+++ b/kippo/core/honeypot.py
@@ -137,10 +137,16 @@ class HoneyPotShell(object):
         self.runCommand()
 
     def showPrompt(self):
+        # Example: nas3:~#
+        #prompt = '%s:%%(path)s' % self.honeypot.hostname
+        # Example: root@nas3:~#     (More of a "Debianu" feel)
+        prompt = '%s@%s:%%(path)s' % (self.honeypot.user.username, self.honeypot.hostname,)
+        # Example: [root@nas3 ~]#   (More of a "CentOS" feel)
+        #prompt = '[%s@%s %%(path)s]' % (self.honeypot.user.username, self.honeypot.hostname,)
         if not self.honeypot.user.uid:
-            prompt = '%s:%%(path)s# ' % self.honeypot.hostname
+            prompt += '# '    # "Root" user
         else:
-            prompt = '%s:%%(path)s$ ' % self.honeypot.hostname
+            prompt += '$ '    # "Non-Root" user
 
         path = self.honeypot.cwd
         homelen = len(self.honeypot.user.home)
@@ -149,6 +155,11 @@ class HoneyPotShell(object):
         elif len(path) > (homelen+1) and \
                 path[:(homelen+1)] == self.honeypot.user.home + '/':
             path = '~' + path[homelen:]
+        # Uncomment the three lines below for a 'better' CenOS look.
+        # Rather than '[root@nas3 /var/log]#' is shows '[root@nas3 log]#'.
+        #path = path.rsplit('/', 1)[-1]
+        #if not path:
+        #    path = '/'
 
         attrs = {'path': path}
         self.honeypot.terminal.write(prompt % attrs)


### PR DESCRIPTION
Looks more like Debian shell prompt now (which is the default base OS).
Check comments for CentOS version.
#### Path: /root

**Current:** `nas3:~#`
**After:** `root@nas3:~#`
_CentOS: `[root@nas3 ~]#`_
#### Path: /var/log

**Current:** `nas3:/var/log#`
**After:** `root@nas3:/var/log#`
_CentOS: `[root@nas3 log]#`_
