### PR TITLE
Add "env" command

### DIFF
--- a/kippo/commands/__init__.py
+++ b/kippo/commands/__init__.py
@@ -14,4 +14,5 @@ __all__ = [
     'last',
     'fs',
     'malware',
+    'env',
     ]

--- a/kippo/commands/env.py
+++ b/kippo/commands/env.py
@@ -1,0 +1,31 @@
+from kippo.core.honeypot import HoneyPotCommand
+
+commands = {}
+
+class command_env(HoneyPotCommand):
+    def call(self):
+        self.defaultenv = {
+            'TERM':            'xterm-256color',
+            'SHELL':           '/bin/bash',
+            'SSH_TTY':         '/dev/pts/0',
+            'USER':            self.honeypot.user.username,
+            'MAIL':            '/var/mail/%s' % self.honeypot.user.username,
+            'PATH':            '/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin',
+            'PWD':             self.honeypot.cwd,
+            'LANG':            'en_US.UTF-8',
+            'SHLVL':           '1',
+            'HOME':            '/root',
+            'LANGUAGE':        'en_GB:en',
+            'LOGNAME':         self.honeypot.user.username,
+            '_':               '/usr/bin/env',
+        }
+
+        if self.env and len(self.env) > 0:
+            self.defaultenv.update(self.env)
+
+        for key, value in self.defaultenv.iteritems():
+            self.writeln("%s=%s" % (key, value))
+
+commands['/usr/bin/env'] = command_env
+
+# vim: set sw=4 et tw=0:


### PR DESCRIPTION
Credit: https://github.com/basilfx/kippo-extra

Result: 

``` bash
root@nas3:~# env
LOGNAME=root
USER=root
HOME=/root
PATH=/bin:/usr/bin:/sbin:/usr/sbin
_=/usr/bin/env
LANG=en_US.UTF-8
TERM=xterm-256color
SHELL=/bin/bash
LANGUAGE=en_GB:en
SHLVL=1
SSH_TTY=/dev/pts/0
PWD=/root
MAIL=/var/mail/root
root@nas3:~# 
```
