### PR TITLE
Add SMTP support. Allows for email notification.

### DIFF
--- a/kippo.cfg.dist
+++ b/kippo.cfg.dist
@@ -147,6 +147,29 @@ interact_enabled = false
 # (default: 5123)
 interact_port = 5123
 
+# SMTP module
+#
+# Email notification on:
+#   + Probe (recommended for LAN use only)
+#   + Successful login
+#   + User quit
+#
+# You are able to use 'ssl' or 'tls' or 'none' to send the message by setting 'smtp_enc'.
+#
+# To enable this module, remove all comments below, including the [smtp] line.
+
+#[smtp]
+#smtp_host = smtp.localhost.net
+#smtp_username = localhost.net
+#smtp_password = password
+#smtp_port = 587
+#smtp_enc = tls
+#email_to = admin@localhost.net
+#email_from = kippo@localhost.net
+#alert_probe = false
+#alert_login = false
+#alert_quit = true
+
 # MySQL logging module
 #
 # Database structure for this module is supplied in doc/sql/mysql.sql

--- a/kippo/core/sendmail.py
+++ b/kippo/core/sendmail.py
@@ -1,0 +1,30 @@
+import smtplib
+from email.mime.text import MIMEText
+from kippo.core.config import config
+
+def sendEmail(subject,  message):
+    cfg = config()
+
+    msg = MIMEText(message)
+    msg['Subject'] = subject
+
+    toEmail = cfg.get('smtp', 'email_to')
+    msg['To'] = toEmail
+
+    fromEmail = cfg.get('smtp', 'email_from')
+    msg['From'] = fromEmail
+
+    smtpHost = cfg.get('smtp', 'smtp_host')
+    smtpPort = cfg.get('smtp', 'smtp_port')
+    smtpUsername = cfg.get('smtp', 'smtp_username')
+    smtpPassword = cfg.get('smtp', 'smtp_Password')
+    smtpEnc = cfg.get('smtp', 'smtp_enc')
+
+    s = smtplib.SMTP(smtpHost, smtpPort)
+    if smtpEnc == 'ssl':
+        s = smtplib.SMTP_SSL(smtpHost, smtpPort)
+    elif smtpEnc == 'tls':
+        s.starttls()
+    s.login(smtpUsername, smtpPassword)
+    s.sendmail(fromEmail, [toEmail], msg.as_string())
+    s.quit()


### PR DESCRIPTION
Email notification on:
- Probe (recommended for LAN use only)
- Successful login
- User quit

Credit: https://github.com/jongreenall/kippo-dirtybastard/

---
#### Probe email

Subject: `[Kippo] SSH Probe`
Message: 

```
There was an SSH probe request.
From: 127.0.0.1:52416.
To: 127.0.0.1:2222.
Kippo Session: 0.
```
#### Login email

Subject: `[Kippo] Successful Login`
Message: 

```
There was a successful login: (root/123456).
```
#### Quit email

Subject: `[Kippo] SSH Attack Finished`
Message: 

```
The attacker quit.

Please check the logs (log/tty/20140605-102239-552.log)!
```
