### PR TITLE
Create textlog session id from peerIP and peerPort

### DIFF
--- a/kippo/dblog/textlog.py
+++ b/kippo/dblog/textlog.py
@@ -4,9 +4,6 @@
 #
 
 from kippo.core import dblog
-from twisted.enterprise import adbapi
-from twisted.internet import defer
-from twisted.python import log
 import time
 
 class DBLogger(dblog.DBLogger):


### PR DESCRIPTION
because both textlog and mysql log create their own session id,
so session id can not be used to search data in mysql db.
This way, there will be usefil data in textlog session id.
- remove unused modules
