### PR TITLE
Add miliseconds to wget download file

### DIFF
--- a/kippo/commands/wget.py
+++ b/kippo/commands/wget.py
@@ -93,9 +93,12 @@ class command_wget(HoneyPotCommand):
         if cfg.has_option('honeypot', 'download_limit_size'):
             self.limit_size = int(cfg.get('honeypot', 'download_limit_size'))
 
-        self.safeoutfile = '%s/%s_%s' % \
+        miliseconds = str("%0.3f" % time.time()).split('.')[1]
+
+        self.safeoutfile = '%s/%s_%s_%s' % \
             (cfg.get('honeypot', 'download_path'),
             time.strftime('%Y%m%d%H%M%S'),
+            miliseconds,
             re.sub('[^A-Za-z0-9]', '_', url))
         self.deferred = self.download(url, outfile, self.safeoutfile)
         if self.deferred:


### PR DESCRIPTION
to distinguish files downloaded almost at the same time

example:
2014-09-29 16:26:51+0200 [HTTPPageDownloader,client] Saving URL (http://www.frade8c.com:9162/root) to dl/20140929162651_http___www_frade8c_com_9162_root
2014-09-29 16:26:52+0200 [HTTPPageDownloader,client] Saving URL (http://www.frade8c.com:9162/root) to dl/20140929162651_http___www_frade8c_com_9162_root
2014-09-29 16:26:52+0200 [HTTPPageDownloader,client] Saving URL (http://www.frade8c.com:9162/root) to dl/20140929162651_http___www_frade8c_com_9162_root
