### PR TITLE
Get uname -a from host system

### DIFF
--- a/kippo/commands/base.py
+++ b/kippo/commands/base.py
@@ -79,9 +79,10 @@ commands['/bin/hostname'] = command_hostname
 class command_uname(HoneyPotCommand):
     def call(self):
         if len(self.args) and self.args[0].strip() in ('-a', '--all'):
-            self.writeln(
-                'Linux %s 2.6.26-2-686 #1 SMP Wed Nov 4 20:45:37 UTC 2009 i686 GNU/Linux' % \
-                self.honeypot.hostname)
+            uname_list = list(os.uname())
+            uname_list[1] = self.honeypot.hostname
+            uname_str = " ".join(uname_list)
+            self.writeln(uname_str)
         else:
             self.writeln('Linux')
 commands['/bin/uname'] = command_uname


### PR DESCRIPTION
It seems that `uname -a` is being used by attackers to quickly identify Kippo. Get this value from the host system, but keep the honeypot hostname. Tested on a live instance.