### PR TITLE
add Dockerfile & docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# configuration shouldn't be baked into the image
+kippo.cfg
+log
+data
+dl
+db/mysql/data/*

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__/
 env/
 env1/
 env2/
+db/mysql/data/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM alpine:3.15
+
+VOLUME /app/data /app/log /app/dl /app/kippo.cfg
+
+# Create a non-root user and switch to it
+RUN adduser -D -H -g '' app
+USER app
+
+# Set the working directory in the container to /app
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Switch back to root to install dependencies
+USER root
+
+RUN apk --update-cache add \
+        python2 \
+        mariadb-connector-c \
+    # build-dependencies can be removed at the end to save space
+    && apk --update-cache add --virtual build-dependencies \
+        git \
+        python2-dev \
+        musl-dev \
+        gcc \
+        mariadb-connector-c-dev \
+    # hack to make the MySQL-python build succeed
+    && wget -q https://raw.githubusercontent.com/paulfitz/mysql-connector-c/8c058fab669d61a14ec23c714e09c8dfd3ec08cd/include/my_config.h -O /usr/include/mysql/my_config.h \
+    && sed '/st_mysql_options options;/a unsigned int reconnect;' /usr/include/mysql/mysql.h -i.bkp \
+    # pip doesn't seem to be available via apk
+    && python -m ensurepip --upgrade \
+    # basic kippo dependencies, including optional MySQL-python
+    && pip install --no-cache-dir \
+        zope.interface==5.5.2 \
+        Twisted==15.1.0 \
+        pycrypto==2.6.1 \
+        pyasn1==0.5.0 \
+        MySQL-python==1.2.5 \
+    # dependencies for XMPP support, needs this ancient custom branch
+    && pip install --no-cache-dir \
+        git+https://github.com/ralphm/wokkel/@e0a70e4b5d03a2c1c911bb2bdf5c3ef717049707 \
+        python-dateutil==2.8.2 \
+    # clean up
+    && apk del build-dependencies
+
+# Switch back to the non-root user
+USER app
+
+# Make port 2222 available to the world outside thiscontainer
+EXPOSE 2222
+
+# Run twistd command when the container launches
+CMD ["twistd", "-n", "-y", "kippo.tac", "--pidfile", "kippo.pid"]

--- a/db/mysql/docker-initdb.d/docker-initdb.sh
+++ b/db/mysql/docker-initdb.d/docker-initdb.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+MYSQL="mariadb -u root -p$MARIADB_ROOT_PASSWORD"
+
+echo "GRANT ALL PRIVILEGES ON $MARIADB_DATABASE.* TO $MARIADB_USER;" | $MYSQL
+
+$MYSQL "$MARIADB_DATABASE" < /sql-scripts/mysql.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+# To run the kippo service, run:
+#   docker-compose up
+#
+# The database service belongs to the "with-db" profile, so it's not run by
+# default. To run the kippo service with the database service, run:
+#   docker-compose --profile with-db up
+#
+version: '3'
+
+services:
+  kippo:
+    image: kippo
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    container_name: kippo
+    restart: unless-stopped
+    ports:
+      - "2222:2222"
+    # logs and configuration should be kept outside the image
+    volumes:
+      - ./log:/app/log
+      - ./dl:/app/dl
+      - ./data:/app/data
+      - ./kippo.cfg:/app/kippo.cfg
+  kippodb:
+    image: mariadb
+    container_name: kippodb
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpw
+      MYSQL_DATABASE: kippo
+      MYSQL_USER: kippo
+      MYSQL_PASSWORD: kippopw
+    volumes:
+      - ./db/mysql/data:/var/lib/mysql
+      - ./db/mysql/docker-initdb.d:/docker-entrypoint-initdb.d
+      - ./doc/sql:/sql-scripts
+    profiles:
+      - with-db
+
+#    ports:
+#      - "3306:3306"

--- a/kippo.cfg.dist
+++ b/kippo.cfg.dist
@@ -161,10 +161,10 @@ interact_port = 5123
 # [database_mysql] line.
 
 #[database_mysql]
-#host = localhost
+#host = kippodb
 #database = kippo
 #username = kippo
-#password = secret
+#password = kippopw
 #port = 3306
 
 # XMPP Logging


### PR DESCRIPTION
In preparation to archiving the repository, I'm adding a Dockerfile and docker-compose.yml. This should let the software to run even with the very ancient dependencies it has.

The Dockerfile should setup a fully working environment for kippo, including optional dependencies (mysql, xmpp).

All data and configuration should be kept outside the container by using volumes. The `docker-compose.yml` has these volumes pointing to the usual directories in the main kippo directory.

This is based on the dockerfile by @aristofanischionis in #241 , but I ended up heavily editing it to use alpine and support docker-compose.

## usage with docker

To build:

```
docker build -t kippo:latest .
```

To use:

```
cp kippo.cfg.dist kippo.cfg
# (and customize kippo.cfg)

docker run \
    -it \
    --rm \
    --name=kippo \
    -p 2222:2222 \
    -v $(pwd)/log:/app/log \
    -v $(pwd)/dl:/app/dl \
    -v $(pwd)/data:/app/data \
    -v $(pwd)/kippo.cfg:/app/kippo.cfg \
    kippo
```

## usage with docker-compose

With the docker-compose.yml, kippo can be run with a single command:

```
docker-compose up
```

To start with the optional mariadb service:

```
docker-compose --profile with-db up
```

## Additional notes

This doesn't seem to work too well with `podman`. I think it doesn't support profiles in `docker-compose.yml`, or the volumes pointing to a file (`kippo.cfg`).